### PR TITLE
removed trait objects from oks.rs and errors.rs

### DIFF
--- a/src/oks.rs
+++ b/src/oks.rs
@@ -1,5 +1,5 @@
 //
-// This Source Co²de Form is subject to the terms of the Mozilla Public
+// This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //

--- a/src/oks.rs
+++ b/src/oks.rs
@@ -1,51 +1,30 @@
 //
-// This Source Code Form is subject to the terms of the Mozilla Public
+// This Source Co²de Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
+use std::iter::*;
+
 use util::*;
 
-#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-pub struct Oks<T>(Box<Iterator<Item = T>>);
+pub use util::Process as Oks;
+// for backward compatibility with previous implementation
+
 
 /// Extension trait for `Iterator<Item = Result<T, E>>` to get all `T`s
-pub trait GetOks<T> {
-    fn oks(self) -> Oks<T>;
+pub trait GetOks<T, E> : Sized {
+    fn oks(self) -> FilterMap<Self, fn(Result<T,E>) -> Option<T>>;
 }
 
-impl<T, E, I> GetOks<T> for I
-    where I: Iterator<Item = Result<T, E>> + 'static,
-          T: 'static,
-          E: 'static
+impl<T, E, I> GetOks<T, E> for I
+    where I: Iterator<Item = Result<T, E>> + Sized
 {
-    fn oks(self) -> Oks<T> {
-        let bx : Box<Iterator<Item = T>> = Box::new(self.filter_map(GetOk::get_ok));
-        Oks(bx)
+    fn oks(self) -> FilterMap<Self, fn(Result<T,E>) -> Option<T>> {
+        self.filter_map(GetOk::get_ok)
     }
 }
 
-impl<T> Iterator for Oks<T> {
-    type Item = T;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next()
-    }
-}
-
-impl<T> Oks<T> {
-
-    /// Process all errors with a lambda
-    pub fn process<R: Default, E, F>(self, f: F) -> Result<R, E>
-        where F: Fn(T) -> Result<R, E>
-    {
-        for element in self {
-            let _ = f(element)?;
-        }
-        Ok(R::default())
-    }
-
-}
 
 #[test]
 fn test_compile() {
@@ -55,7 +34,5 @@ fn test_compile() {
         .into_iter()
         .map(|e| usize::from_str(e))
         .oks()
-        .process(|e| { println!("Error: {:?}", e); Ok(()) });
+        .process(|o| { println!("Ok: {:?}", o); Ok(()) });
 }
-
-

--- a/src/util.rs
+++ b/src/util.rs
@@ -34,7 +34,8 @@ pub trait Process<T> {
 impl<I: Iterator> Process<I::Item> for I {
     /// Process all errors with a lambda
     fn process<R: Default, E, F>(self, f: F) -> Result<R, E>
-        where F: Fn(I::Item) -> Result<R, E> {
+        where F: Fn(I::Item) -> Result<R, E>
+        {
             for element in self {
                 let _ = f(element)?;
             }

--- a/src/util.rs
+++ b/src/util.rs
@@ -35,10 +35,10 @@ impl<I: Iterator> Process<I::Item> for I {
     /// Process all errors with a lambda
     fn process<R: Default, E, F>(self, f: F) -> Result<R, E>
         where F: Fn(I::Item) -> Result<R, E>
-        {
-            for element in self {
-                let _ = f(element)?;
-            }
-            Ok(R::default())
+    {
+        for element in self {
+            let _ = f(element)?;
         }
+        Ok(R::default())
+    }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -24,3 +24,20 @@ impl<T, E> GetOk<T> for Result<T, E> {
     }
 }
 
+
+/// Extend any Iterator with a `process` method, equivalent to a fallible for_each.
+pub trait Process<T> {
+    fn process<R: Default, E, F>(self, f: F) -> Result<R, E>
+        where F: Fn(T) -> Result<R, E>;
+}
+
+impl<I: Iterator> Process<I::Item> for I {
+    /// Process all errors with a lambda
+    fn process<R: Default, E, F>(self, f: F) -> Result<R, E>
+        where F: Fn(I::Item) -> Result<R, E> {
+            for element in self {
+                let _ = f(element)?;
+            }
+            Ok(R::default())
+        }
+}


### PR DESCRIPTION
this new implementations should be more efficient,
and more faithful to the "zero-cost abstraction" mantra.

As a consequence, I had to move the 'process' method to a generic trait,
defined in util.rs and implemented by any Iterator.

A another consequence,
the 'static lifetime bound on the iterator can also be removed.