### PR TITLE
added the try_collect extension

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@
 //! * Select only `Ok(_)`s from the Iterator
 //! * Do something in the `Err(_)` case, but don't change the error-object
 //! * Do something in the `Ok(_)` case, but don't change the ok-object
+//! * Collect `OK(_)`s from the Iterators, propagating the first error if any
 //!
 //! # Usecase
 //!
@@ -189,6 +190,22 @@
 //! # }
 //! ```
 //!
+//! * Collecting values if there is no error, otherwise propagating the first error
+//!
+//! ```
+//! # fn main() -> Result<(), ::std::num::ParseIntError> {
+//! use std::str::FromStr;
+//! use resiter::try_collect::*;
+//!
+//! let v: Vec<usize> = ["1", "2", "4", "5"]
+//!     .into_iter()
+//!     .map(|e| usize::from_str(e))
+//!     .try_collect()?;
+//! assert!(v.len() == 4);
+//! Ok(())
+//! # }
+//! ```
+//!
 //! # License
 //!
 //! MPL 2.0
@@ -201,6 +218,7 @@ pub mod oks;
 pub mod onerr;
 pub mod onok;
 pub mod prelude;
+pub mod try_collect;
 pub mod unwrap;
 mod util;
 pub mod while_ok;

--- a/src/try_collect.rs
+++ b/src/try_collect.rs
@@ -1,0 +1,59 @@
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+use std::iter::FromIterator;
+
+/// Extension trait for `Iterator<Item = Result<T, E>>` to collect values if there is no error.
+pub trait TryCollectExt<T, E> {
+    fn try_collect<B>(&mut self) -> Result<B, E>
+    where
+        B: FromIterator<T>;
+}
+
+impl<T, E, I> TryCollectExt<T, E> for I
+where
+    I: Iterator<Item=Result<T,E>>
+{
+    fn try_collect<B>(&mut self) -> Result<B, E>
+    where
+        B: FromIterator<T>
+    {
+        let mut error: Option<E> = None;
+        let collected = self
+        .map(|i| match i {
+            Ok(v)  => Some(v),
+            Err(e) => {
+                error = Some(e);
+                None
+            }
+        })
+        .take_while(|i| i.is_some())
+        .map(|i| i.unwrap())
+        .collect();
+
+        match error {
+            None => Ok(collected),
+            Some(e) => Err(e)
+        }
+    }
+}
+
+#[test]
+fn test_try_collect() {
+    let r1: Result<Vec<usize>, &'static str> =
+        vec![ Ok(1), Ok(2), Ok(3), Err("error"), Ok(4) ]
+        .into_iter()
+        .try_collect();
+    assert!(r1.is_err());
+
+    let r2: Result<Vec<usize>, &'static str> =
+        vec![ Ok(1), Ok(2), Ok(3), Ok(4) ]
+        .into_iter()
+        .try_collect();
+    assert!(r2.is_ok());
+    assert!(r2.unwrap().len() == 4);
+}
+


### PR DESCRIPTION
The goal of this extension is to ease provide a counterpart
to the standard 'Iterator::collect' method.

`try_collect` returns a collection of the iterator has no error;
otherwise, the first encountered error is returned.