### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/and_then.rs
+++ b/src/and_then.rs
@@ -91,7 +91,7 @@ fn test_and_then_ok() {
     use std::str::FromStr;
 
     let mapped: Vec<_> = ["1", "2", "a", "b", "4", "5"]
-        .into_iter()
+        .iter()
         .map(|txt| usize::from_str(txt).map_err(|e| (txt, e)))
         .and_then_ok(|i| Ok(2 * i))
         .and_then_err(|(txt, e)| if txt == &"a" { Ok(15) } else { Err(e) })


### PR DESCRIPTION
Use `slice::iter` instead of `into_iter` to avoid future breakage

`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.
