### PR TITLE
Add no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Matthias Beyer <mail@beyermatthias.de>",
 description = "Helper crate for handling iterators over result"
 
 keywords    = ["iterator", "result", "util"]
-categories  = ["no-std"]
+categories  = ["algorithms", "no-std", "rust-patterns"]
 readme      = "README.md"
 license     = "MPL-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Matthias Beyer <mail@beyermatthias.de>",
 description = "Helper crate for handling iterators over result"
 
 keywords    = ["iterator", "result", "util"]
+categories  = ["no-std"]
 readme      = "README.md"
 license     = "MPL-2.0"
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -12,14 +12,15 @@ pub use util::Process as Errors;
 // for backward compatibility with previous implementation
 
 /// Extension trait for `Iterator<Item = Result<T, E>>` to get all `E`s
-pub trait GetErrors<T, E> : Sized {
-    fn errors(self) -> FilterMap<Self, fn(Result<T,E>) -> Option<E>>;
+pub trait GetErrors<T, E>: Sized {
+    fn errors(self) -> FilterMap<Self, fn(Result<T, E>) -> Option<E>>;
 }
 
 impl<T, E, I> GetErrors<T, E> for I
-    where I: Iterator<Item = Result<T, E>> + Sized
+where
+    I: Iterator<Item = Result<T, E>> + Sized,
 {
-    fn errors(self) -> FilterMap<Self, fn(Result<T,E>) -> Option<E>> {
+    fn errors(self) -> FilterMap<Self, fn(Result<T, E>) -> Option<E>> {
         self.filter_map(GetErr::get_err)
     }
 }
@@ -28,10 +29,12 @@ impl<T, E, I> GetErrors<T, E> for I
 fn test_compile() {
     use std::str::FromStr;
 
-    let _ : Result<_, ::std::num::ParseIntError> = ["1", "2", "3", "4", "5"]
+    let _: Result<_, ::std::num::ParseIntError> = ["1", "2", "3", "4", "5"]
         .into_iter()
         .map(|e| usize::from_str(e))
         .errors()
-        .process(|e| { println!("Error: {:?}", e); Ok(()) });
+        .process(|e| {
+            println!("Error: {:?}", e);
+            Ok(())
+        });
 }
-

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,7 +4,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use std::iter::*;
+use core::iter::*;
 
 use util::*;
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -132,10 +132,10 @@ where
         loop {
             match self.iter.next() {
                 Some(Ok(x)) => match (self.f)(&x) {
-                    Ok(true)  => return Some(Ok(x)),
+                    Ok(true) => return Some(Ok(x)),
                     Ok(false) => continue,
-                    Err(e)    => return Some(Err(e))
-                }
+                    Err(e) => return Some(Err(e)),
+                },
 
                 other => return other,
             }
@@ -217,4 +217,3 @@ fn test_filter_ok_and_then() {
     assert_eq!(v.iter().filter(|x| x.is_ok()).count(), 2);
     assert_eq!(v.iter().filter(|x| x.is_err()).count(), 1);
 }
-

--- a/src/filter_map.rs
+++ b/src/filter_map.rs
@@ -109,7 +109,8 @@ fn test_filter_map_ok() {
         Ok("5"),
         Err("b"),
         Err("8"),
-    ].into_iter()
+    ]
+    .into_iter()
     .filter_map_ok(|txt| usize::from_str(txt).ok())
     .filter_map_err(|txt| usize::from_str(txt).ok().map(|i| i * 3))
     .collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,6 +194,9 @@
 //! MPL 2.0
 //!
 
+#![cfg(not(test))]
+#![no_std]
+
 pub mod and_then;
 pub mod errors;
 pub mod filter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,6 @@
 //! * Consuming iterators until an error occurs
 //!
 //! ```
-//! # fn main() {
 //! use std::str::FromStr;
 //! use resiter::errors::*;
 //!
@@ -45,13 +44,11 @@
 //!     .map(|e| usize::from_str(e))
 //!     .errors()
 //!     .next(); // "4" and "5" will never be processed by the iterator
-//! # }
 //! ```
 //!
 //! * Consuming iterators and collect all errors
 //!
 //! ```
-//! # fn main() {
 //! use std::str::FromStr;
 //! use resiter::errors::*;
 //!
@@ -62,13 +59,11 @@
 //!     .collect::<Vec<::std::num::ParseIntError>>()
 //!     .len();
 //! assert_eq!(len, 1);
-//! # }
 //! ```
 //!
 //! * Consuming iterators and collect all oks
 //!
 //! ```
-//! # fn main() {
 //! use std::str::FromStr;
 //! use resiter::oks::*;
 //!
@@ -79,13 +74,11 @@
 //!     .collect::<Vec<_>>()
 //!     .len();
 //! assert_eq!(len, 4);
-//! # }
 //! ```
 //!
 //! * Printing errors / oks
 //!
 //! ```
-//! # fn main() {
 //! use std::str::FromStr;
 //! use resiter::oks::*;
 //! use resiter::onerr::*;
@@ -100,13 +93,11 @@
 //!     .collect::<Vec<_>>()
 //!     .len();
 //! assert_eq!(len, 4);
-//! # }
 //! ```
 //!
 //! * Transforming oks
 //!
 //! ```
-//! # fn main() {
 //! use std::str::FromStr;
 //! use resiter::map::*;
 //!
@@ -117,13 +108,11 @@
 //!     .collect::<Vec<_>>();
 //! assert_eq!(doubles[0], Ok(2));
 //! assert_eq!(doubles[1], Ok(4));
-//! # }
 //! ```
 //!
 //! * Transforming errors
 //!
 //! ```
-//! # fn main() {
 //! use std::str::FromStr;
 //! use resiter::map::*;
 //!
@@ -133,13 +122,11 @@
 //!     .map_err(|e| format!("{:?}", e))
 //!     .collect::<Vec<_>>();
 //! assert_eq!(doubles[2], Err("ParseIntError { kind: InvalidDigit }".to_string()));
-//! # }
 //! ```
 //!
 //! * Filtering oks (leaving errors as is)
 //!
 //! ```
-//! # fn main() {
 //! use std::str::FromStr;
 //! use resiter::filter::*;
 //!
@@ -150,13 +137,11 @@
 //!     .collect::<Vec<_>>();
 //! assert_eq!(doubles.len(), 3);
 //! assert_eq!(doubles[0], Ok(2));
-//! # }
 //! ```
 //!
 //! * Filtering errors (leaving oks as is)
 //!
 //! ```
-//! # fn main() {
 //! use std::str::FromStr;
 //! use resiter::filter::*;
 //!
@@ -167,13 +152,11 @@
 //!     .collect::<Vec<_>>();
 //! assert_eq!(doubles.len(), 4);
 //! assert_eq!(doubles[2], Ok(4));
-//! # }
 //! ```
 //!
 //! * Stopping the iteration on the first error
 //!
 //! ```
-//! # fn main() -> () {
 //! use std::str::FromStr;
 //! use resiter::while_ok::*;
 //!
@@ -186,7 +169,6 @@
 //! if res.is_err() {
 //!     println!("An error occured");
 //! }
-//! # }
 //! ```
 //!
 //! # License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,7 +220,7 @@ pub use filter_map::FilterMap;
 pub use flat_map::FlatMap;
 pub use flatten::Flatten;
 pub use map::Map;
-pub use ok_or_else::{ResultOptionExt, IterInnerOkOrElse};
+pub use ok_or_else::{IterInnerOkOrElse, ResultOptionExt};
 pub use oks::GetOks;
 pub use onerr::OnErrDo;
 pub use onok::OnOkDo;

--- a/src/ok_or_else.rs
+++ b/src/ok_or_else.rs
@@ -6,24 +6,24 @@
 
 /// Extension trait for doing `Result<Option<T>, E>  ->  Result<T, E>`
 pub trait ResultOptionExt<T, E, F>
-    where T: Sized,
-          E: Sized,
-          F: FnOnce() -> E
+where
+    T: Sized,
+    E: Sized,
+    F: FnOnce() -> E,
 {
     fn inner_ok_or_else(self, f: F) -> Result<T, E>;
 }
 
 impl<T, E, F> ResultOptionExt<T, E, F> for Result<Option<T>, E>
-    where T: Sized,
-          E: Sized,
-          F: FnOnce() -> E
+where
+    T: Sized,
+    E: Sized,
+    F: FnOnce() -> E,
 {
     fn inner_ok_or_else(self, f: F) -> Result<T, E> {
         self.and_then(|opt| opt.ok_or_else(f))
     }
 }
-
-
 
 /// Extension trait for doing
 ///
@@ -32,25 +32,28 @@ impl<T, E, F> ResultOptionExt<T, E, F> for Result<Option<T>, E>
 /// ```
 ///
 pub trait IterInnerOkOrElse<T, E, F>
-    where T: Sized,
-          E: Sized,
-          Self: Iterator<Item = Result<Option<T>, E>> + Sized,
-          F: Fn() -> E,
+where
+    T: Sized,
+    E: Sized,
+    Self: Iterator<Item = Result<Option<T>, E>> + Sized,
+    F: Fn() -> E,
 {
     fn map_inner_ok_or_else(self, f: F) -> IterInnerOkOrElseImpl<Self, T, E, F>;
 }
 
 pub struct IterInnerOkOrElseImpl<I, T, E, F>(I, F)
-    where I: Iterator<Item = Result<Option<T>, E>> + Sized,
-          T: Sized,
-          E: Sized,
-          F: Fn() -> E;
+where
+    I: Iterator<Item = Result<Option<T>, E>> + Sized,
+    T: Sized,
+    E: Sized,
+    F: Fn() -> E;
 
 impl<I, T, E, F> IterInnerOkOrElse<T, E, F> for I
-    where I: Iterator<Item = Result<Option<T>, E>> + Sized,
-          T: Sized,
-          E: Sized,
-          F: Fn() -> E,
+where
+    I: Iterator<Item = Result<Option<T>, E>> + Sized,
+    T: Sized,
+    E: Sized,
+    F: Fn() -> E,
 {
     fn map_inner_ok_or_else(self, f: F) -> IterInnerOkOrElseImpl<I, T, E, F> {
         IterInnerOkOrElseImpl(self, f)
@@ -58,23 +61,25 @@ impl<I, T, E, F> IterInnerOkOrElse<T, E, F> for I
 }
 
 impl<I, T, E, F> Iterator for IterInnerOkOrElseImpl<I, T, E, F>
-    where I: Iterator<Item = Result<Option<T>, E>> + Sized,
-          T: Sized,
-          E: Sized,
-          F: Fn() -> E,
+where
+    I: Iterator<Item = Result<Option<T>, E>> + Sized,
+    T: Sized,
+    E: Sized,
+    F: Fn() -> E,
 {
     type Item = Result<T, E>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|e| e.and_then(|opt| opt.ok_or_else(|| (self.1)())))
+        self.0
+            .next()
+            .map(|e| e.and_then(|opt| opt.ok_or_else(|| (self.1)())))
     }
 }
 
-
 #[test]
 fn compile_test_1() {
-    let v : Vec<i32> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
-    let _ : Result<Vec<i32>, &'static str> = v
+    let v: Vec<i32> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
+    let _: Result<Vec<i32>, &'static str> = v
         .into_iter()
         .map(Some)
         .map(Ok)
@@ -84,8 +89,19 @@ fn compile_test_1() {
 
 #[test]
 fn compile_test_2() {
-    let v : Vec<Option<i32>> = vec![Some(1), Some(2), Some(3), Some(4), Some(5), Some(6), Some(7), Some(8), Some(9), Some(0)];
-    let _ : Result<Vec<i32>, &'static str> = v
+    let v: Vec<Option<i32>> = vec![
+        Some(1),
+        Some(2),
+        Some(3),
+        Some(4),
+        Some(5),
+        Some(6),
+        Some(7),
+        Some(8),
+        Some(9),
+        Some(0),
+    ];
+    let _: Result<Vec<i32>, &'static str> = v
         .into_iter()
         .map(Ok)
         .map_inner_ok_or_else(|| "error message")
@@ -94,8 +110,8 @@ fn compile_test_2() {
 
 #[test]
 fn compile_test_3() {
-    let v : Vec<i32> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
-    let r : Result<Vec<i32>, &'static str> = v
+    let v: Vec<i32> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
+    let r: Result<Vec<i32>, &'static str> = v
         .into_iter()
         .map(|i| if i < 5 { Some(i) } else { None })
         .map(Ok)
@@ -110,13 +126,13 @@ fn compile_test_3() {
 fn compile_test_4() {
     use std::collections::HashMap;
 
-    let v : Vec<i32> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
+    let v: Vec<i32> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
     let mut h = HashMap::new();
     (0..10).into_iter().for_each(|e| {
         h.insert(e, e);
     });
 
-    let r : Result<Vec<_>, &'static str> = v
+    let r: Result<Vec<_>, &'static str> = v
         .into_iter()
         .chain(::std::iter::once(10))
         .map(|e| Ok(h.get(&e)))
@@ -126,4 +142,3 @@ fn compile_test_4() {
     assert!(r.is_err());
     assert_eq!(r.unwrap_err(), "at least one key missing");
 }
-

--- a/src/oks.rs
+++ b/src/oks.rs
@@ -11,28 +11,30 @@ use util::*;
 pub use util::Process as Oks;
 // for backward compatibility with previous implementation
 
-
 /// Extension trait for `Iterator<Item = Result<T, E>>` to get all `T`s
-pub trait GetOks<T, E> : Sized {
-    fn oks(self) -> FilterMap<Self, fn(Result<T,E>) -> Option<T>>;
+pub trait GetOks<T, E>: Sized {
+    fn oks(self) -> FilterMap<Self, fn(Result<T, E>) -> Option<T>>;
 }
 
 impl<T, E, I> GetOks<T, E> for I
-    where I: Iterator<Item = Result<T, E>> + Sized
+where
+    I: Iterator<Item = Result<T, E>> + Sized,
 {
-    fn oks(self) -> FilterMap<Self, fn(Result<T,E>) -> Option<T>> {
+    fn oks(self) -> FilterMap<Self, fn(Result<T, E>) -> Option<T>> {
         self.filter_map(GetOk::get_ok)
     }
 }
-
 
 #[test]
 fn test_compile() {
     use std::str::FromStr;
 
-    let _ : Result<_, ::std::num::ParseIntError> = ["1", "2", "3", "4", "5"]
+    let _: Result<_, ::std::num::ParseIntError> = ["1", "2", "3", "4", "5"]
         .into_iter()
         .map(|e| usize::from_str(e))
         .oks()
-        .process(|o| { println!("Ok: {:?}", o); Ok(()) });
+        .process(|o| {
+            println!("Ok: {:?}", o);
+            Ok(())
+        });
 }

--- a/src/oks.rs
+++ b/src/oks.rs
@@ -4,7 +4,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 
-use std::iter::*;
+use core::iter::*;
 
 use util::*;
 

--- a/src/onerr.rs
+++ b/src/onerr.rs
@@ -6,20 +6,23 @@
 
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct OnErr<I, O, E, F>(I, F)
-    where I: Iterator<Item = Result<O, E>>,
-          F: Fn(&E) -> ();
+where
+    I: Iterator<Item = Result<O, E>>,
+    F: Fn(&E) -> ();
 
 /// Extension trait for `Iterator<Item = Result<T, E>>` to do something on `Err(_)`
 pub trait OnErrDo<I, O, E, F>
-    where I: Iterator<Item = Result<O, E>>,
-          F: Fn(&E) -> ()
+where
+    I: Iterator<Item = Result<O, E>>,
+    F: Fn(&E) -> (),
 {
     fn on_err(self, F) -> OnErr<I, O, E, F>;
 }
 
 impl<I, O, E, F> OnErrDo<I, O, E, F> for I
-    where I: Iterator<Item = Result<O, E>>,
-          F: Fn(&E) -> ()
+where
+    I: Iterator<Item = Result<O, E>>,
+    F: Fn(&E) -> (),
 {
     fn on_err(self, f: F) -> OnErr<I, O, E, F> {
         OnErr(self, f)
@@ -27,13 +30,19 @@ impl<I, O, E, F> OnErrDo<I, O, E, F> for I
 }
 
 impl<I, O, E, F> Iterator for OnErr<I, O, E, F>
-    where I: Iterator<Item = Result<O, E>>,
-          F: Fn(&E) -> ()
+where
+    I: Iterator<Item = Result<O, E>>,
+    F: Fn(&E) -> (),
 {
     type Item = Result<O, E>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|r| r.map_err(|e| {(self.1)(&e); e }))
+        self.0.next().map(|r| {
+            r.map_err(|e| {
+                (self.1)(&e);
+                e
+            })
+        })
     }
 }
 
@@ -41,7 +50,7 @@ impl<I, O, E, F> Iterator for OnErr<I, O, E, F>
 fn test_compile_1() {
     use std::str::FromStr;
 
-    let _ : Vec<Result<usize, ::std::num::ParseIntError>> = ["1", "2", "3", "4", "5"]
+    let _: Vec<Result<usize, ::std::num::ParseIntError>> = ["1", "2", "3", "4", "5"]
         .into_iter()
         .map(|e| usize::from_str(e))
         .on_err(|e| println!("Error: {:?}", e))

--- a/src/onok.rs
+++ b/src/onok.rs
@@ -6,20 +6,23 @@
 
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct OnOk<I, O, E, F>(I, F)
-    where I: Iterator<Item = Result<O, E>>,
-          F: Fn(&O) -> ();
+where
+    I: Iterator<Item = Result<O, E>>,
+    F: Fn(&O) -> ();
 
 /// Extension trait for `Iterator<Item = Result<T, E>>` to do something on `Ok(_)`
 pub trait OnOkDo<I, O, E, F>
-    where I: Iterator<Item = Result<O, E>>,
-          F: Fn(&O) -> ()
+where
+    I: Iterator<Item = Result<O, E>>,
+    F: Fn(&O) -> (),
 {
     fn on_ok(self, F) -> OnOk<I, O, E, F>;
 }
 
 impl<I, O, E, F> OnOkDo<I, O, E, F> for I
-    where I: Iterator<Item = Result<O, E>>,
-          F: Fn(&O) -> ()
+where
+    I: Iterator<Item = Result<O, E>>,
+    F: Fn(&O) -> (),
 {
     fn on_ok(self, f: F) -> OnOk<I, O, E, F> {
         OnOk(self, f)
@@ -27,13 +30,19 @@ impl<I, O, E, F> OnOkDo<I, O, E, F> for I
 }
 
 impl<I, O, E, F> Iterator for OnOk<I, O, E, F>
-    where I: Iterator<Item = Result<O, E>>,
-          F: Fn(&O) -> ()
+where
+    I: Iterator<Item = Result<O, E>>,
+    F: Fn(&O) -> (),
 {
     type Item = Result<O, E>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|r| r.map(|o| {(self.1)(&o); o }))
+        self.0.next().map(|r| {
+            r.map(|o| {
+                (self.1)(&o);
+                o
+            })
+        })
     }
 }
 
@@ -41,10 +50,9 @@ impl<I, O, E, F> Iterator for OnOk<I, O, E, F>
 fn test_compile_1() {
     use std::str::FromStr;
 
-    let _ : Vec<Result<usize, ::std::num::ParseIntError>> = ["1", "2", "3", "4", "5"]
+    let _: Vec<Result<usize, ::std::num::ParseIntError>> = ["1", "2", "3", "4", "5"]
         .into_iter()
         .map(|e| usize::from_str(e))
         .on_ok(|e| println!("Ok: {:?}", e))
         .collect();
 }
-

--- a/src/unwrap.rs
+++ b/src/unwrap.rs
@@ -13,22 +13,26 @@
 ///
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct UnwrapWith<I, O, E, F>(I, F)
-    where I: Iterator<Item = Result<O, E>>,
-          F: FnMut(E) -> Option<O>;
+where
+    I: Iterator<Item = Result<O, E>>,
+    F: FnMut(E) -> Option<O>;
 
 impl<I, O, E, F> Iterator for UnwrapWith<I, O, E, F>
-    where I: Iterator<Item = Result<O, E>>,
-          F: FnMut(E) -> Option<O>
+where
+    I: Iterator<Item = Result<O, E>>,
+    F: FnMut(E) -> Option<O>,
 {
     type Item = O;
 
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(o) = self.0.next() {
             match o {
-                Ok(t)  => return Some(t),
-                Err(e) => if let Some(t) = (self.1)(e) {
-                    return Some(t);
-                },
+                Ok(t) => return Some(t),
+                Err(e) => {
+                    if let Some(t) = (self.1)(e) {
+                        return Some(t);
+                    }
+                }
             }
         }
 
@@ -37,15 +41,17 @@ impl<I, O, E, F> Iterator for UnwrapWith<I, O, E, F>
 }
 
 pub trait UnwrapWithExt<I, O, E, F>
-    where I: Iterator<Item = Result<O, E>>,
-          F: FnMut(E) -> Option<O>
+where
+    I: Iterator<Item = Result<O, E>>,
+    F: FnMut(E) -> Option<O>,
 {
     fn unwrap_with(self, F) -> UnwrapWith<I, O, E, F>;
 }
 
 impl<I, O, E, F> UnwrapWithExt<I, O, E, F> for I
-    where I: Iterator<Item = Result<O, E>>,
-          F: FnMut(E) -> Option<O>
+where
+    I: Iterator<Item = Result<O, E>>,
+    F: FnMut(E) -> Option<O>,
 {
     fn unwrap_with(self, f: F) -> UnwrapWith<I, O, E, F> {
         UnwrapWith(self, f)
@@ -56,10 +62,9 @@ impl<I, O, E, F> UnwrapWithExt<I, O, E, F> for I
 fn test_compile_1() {
     use std::str::FromStr;
 
-    let _ : Vec<usize> = ["1", "2", "3", "4", "5"]
+    let _: Vec<usize> = ["1", "2", "3", "4", "5"]
         .into_iter()
         .map(|e| usize::from_str(e))
         .unwrap_with(|_| None) // ignore errors
         .collect();
 }
-

--- a/src/util.rs
+++ b/src/util.rs
@@ -24,17 +24,18 @@ impl<T, E> GetOk<T> for Result<T, E> {
     }
 }
 
-
 /// Extend any Iterator with a `process` method, equivalent to a fallible for_each.
 pub trait Process<T> {
     fn process<R: Default, E, F>(self, f: F) -> Result<R, E>
-        where F: Fn(T) -> Result<R, E>;
+    where
+        F: Fn(T) -> Result<R, E>;
 }
 
 impl<I: Iterator> Process<I::Item> for I {
     /// Process all errors with a lambda
     fn process<R: Default, E, F>(self, f: F) -> Result<R, E>
-        where F: Fn(I::Item) -> Result<R, E>
+    where
+        F: Fn(I::Item) -> Result<R, E>,
     {
         for element in self {
             let _ = f(element)?;

--- a/src/while_ok.rs
+++ b/src/while_ok.rs
@@ -5,17 +5,19 @@
 //
 
 /// Extension trait for `Iterator<Item = Result<O, E>>` to iter until an error is encountered.
-pub trait WhileOk<O, E>
-{
+pub trait WhileOk<O, E> {
     fn while_ok<F>(self, F) -> Result<(), E>
-        where F: FnMut(O) -> ();
+    where
+        F: FnMut(O) -> ();
 }
 
 impl<I, O, E> WhileOk<O, E> for I
-    where I: Iterator<Item = Result<O, E>>,
+where
+    I: Iterator<Item = Result<O, E>>,
 {
     fn while_ok<F>(self, mut f: F) -> Result<(), E>
-        where F: FnMut(O) -> ()
+    where
+        F: FnMut(O) -> (),
     {
         for res in self {
             f(res?);
@@ -23,8 +25,6 @@ impl<I, O, E> WhileOk<O, E> for I
         Ok(())
     }
 }
-
-
 
 #[test]
 fn test_while_ok_ok() {


### PR DESCRIPTION
Thus allowing it to be used in more cases.

Also:
- Run `cargo fmt`
  Because why not?
- Remove unnecessary `fn main()` in doctests
  As reported by `cargo clippy`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/matthiasbeyer/resiter/22)
<!-- Reviewable:end -->
