### PR TITLE
Converted test to docbook test and made the test more readable

### DIFF
--- a/src/and_then_filter.rs
+++ b/src/and_then_filter.rs
@@ -82,15 +82,14 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            match self.iter.next() {
+            return match self.iter.next() {
                 Some(Ok(x)) => match (self.f)(x) {
-                    Some(Err(e)) => return Some(Err(e)),
-                    Some(Ok(o)) => return Some(Ok(o)),
+                    Some(r) => Some(r),
                     None => continue,
                 },
-                Some(Err(e)) => return Some(Err(e)),
-                None => return None,
-            }
+                Some(Err(e)) => Some(Err(e)),
+                None => None,
+            };
         }
     }
 


### PR DESCRIPTION
I thought resiter would benefit from examples in the api-docuentation. I made this change to illustrate.

When I looked at the `and_then_filter.rs` it looks lke it impleents `try_filter_map_ok` as per the previous pullrequest naming. Perhaps `try_filter_ok`whould move from `filter`to this module? And this module could be renamed to `try_filter`to collect all trelated try_filter-methods?

If that sounds like a good idea I would be happy to put in some work to get it done, and if you agree that doctests would be a good idea I'd be happy to put in some work to give the API-documenttaion some love by primarily converting some of the existing tests to doctests.


