### PR TITLE
Organize try filter

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -12,10 +12,6 @@ pub trait Filter<O, E>: Sized {
     fn filter_err<F>(self, _: F) -> FilterErr<Self, F>
     where
         F: FnMut(&E) -> bool;
-
-    fn try_filter_ok<F>(self, _: F) -> TryFilterOk<Self, F>
-    where
-        F: FnMut(&O) -> Result<bool, E>;
 }
 
 impl<I, O, E> Filter<O, E> for I
@@ -33,15 +29,6 @@ where
         F: FnMut(&E) -> bool,
     {
         FilterErr { iter: self, f }
-    }
-
-    /// Extension for `Iterator<Item = Result<O, E>>` to filter the Ok(_) and leaving the Err(_) as
-    /// is, but allowing the filter to return a `Result<bool, E>` itself
-    fn try_filter_ok<F>(self, f: F) -> TryFilterOk<Self, F>
-    where
-        F: FnMut(&O) -> Result<bool, E>,
-    {
-        TryFilterOk { iter: self, f }
     }
 }
 
@@ -115,40 +102,6 @@ where
     }
 }
 
-#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-pub struct TryFilterOk<I, F> {
-    iter: I,
-    f: F,
-}
-
-impl<I, O, E, F> Iterator for TryFilterOk<I, F>
-where
-    I: Iterator<Item = Result<O, E>>,
-    F: FnMut(&O) -> Result<bool, E>,
-{
-    type Item = Result<O, E>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            match self.iter.next() {
-                Some(Ok(x)) => match (self.f)(&x) {
-                    Ok(true) => return Some(Ok(x)),
-                    Ok(false) => continue,
-                    Err(e) => return Some(Err(e)),
-                },
-
-                other => return other,
-            }
-        }
-    }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let hint_sup = self.iter.size_hint().1;
-        (0, hint_sup)
-    }
-}
-
 #[test]
 fn test_filter_ok() {
     use std::str::FromStr;
@@ -201,19 +154,4 @@ fn test_filter_err_hint() {
         .size_hint();
 
     assert_eq!(hint, (0, Some(5)));
-}
-
-#[test]
-fn test_try_filter_ok() {
-    use std::str::FromStr;
-
-    let v = ["1", "2", "a", "4", "5"]
-        .iter()
-        .map(Ok)
-        .try_filter_ok(|e| usize::from_str(e).map(|txt| txt < 3))
-        .collect::<Vec<Result<_, _>>>();
-
-    assert_eq!(v.len(), 3);
-    assert_eq!(v.iter().filter(|x| x.is_ok()).count(), 2);
-    assert_eq!(v.iter().filter(|x| x.is_err()).count(), 1);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,6 @@
 #![cfg_attr(not(test), no_std)]
 
 pub mod and_then;
-pub mod and_then_filter;
 pub mod errors;
 pub mod filter;
 pub mod filter_map;
@@ -191,12 +190,13 @@ pub mod oks;
 pub mod onerr;
 pub mod onok;
 pub mod prelude;
+pub mod try_filter;
+pub mod try_filter_map;
 pub mod unwrap;
 mod util;
 pub mod while_ok;
 
 pub use and_then::AndThen;
-pub use and_then_filter::AndThenFilter;
 pub use errors::GetErrors;
 pub use filter::Filter;
 pub use filter_map::FilterMap;
@@ -207,6 +207,7 @@ pub use ok_or_else::{IterInnerOkOrElse, ResultOptionExt};
 pub use oks::GetOks;
 pub use onerr::OnErrDo;
 pub use onok::OnOkDo;
+pub use try_filter_map::TryFilterMap;
 pub use unwrap::UnwrapWithExt;
 pub use util::{GetErr, GetOk, Process};
 pub use while_ok::WhileOk;

--- a/src/try_filter.rs
+++ b/src/try_filter.rs
@@ -56,15 +56,14 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            match self.iter.next() {
+            return match self.iter.next() {
                 Some(Ok(x)) => match (self.f)(&x) {
-                    Ok(true) => return Some(Ok(x)),
+                    Ok(true) => Some(Ok(x)),
                     Ok(false) => continue,
-                    Err(e) => return Some(Err(e)),
+                    Err(e) => Some(Err(e)),
                 },
-
-                other => return other,
-            }
+                other => other,
+            };
         }
     }
 

--- a/src/try_filter.rs
+++ b/src/try_filter.rs
@@ -1,0 +1,74 @@
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+pub trait TryFilter<O, E>: Sized {
+    fn try_filter_ok<F>(self, _: F) -> TryFilterOk<Self, F>
+    where
+        F: FnMut(&O) -> Result<bool, E>;
+}
+
+impl<I, O, E> TryFilter<O, E> for I
+where
+    I: Iterator<Item = Result<O, E>> + Sized,
+{
+    /// Extension for `Iterator<Item = Result<O, E>>` to filter the Ok(_) and leaving the Err(_) as
+    /// is, but allowing the filter to return a `Result<bool, E>` itself
+    fn try_filter_ok<F>(self, f: F) -> TryFilterOk<Self, F>
+    where
+        F: FnMut(&O) -> Result<bool, E>,
+    {
+        TryFilterOk { iter: self, f }
+    }
+}
+
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct TryFilterOk<I, F> {
+    iter: I,
+    f: F,
+}
+
+impl<I, O, E, F> Iterator for TryFilterOk<I, F>
+where
+    I: Iterator<Item = Result<O, E>>,
+    F: FnMut(&O) -> Result<bool, E>,
+{
+    type Item = Result<O, E>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match self.iter.next() {
+                Some(Ok(x)) => match (self.f)(&x) {
+                    Ok(true) => return Some(Ok(x)),
+                    Ok(false) => continue,
+                    Err(e) => return Some(Err(e)),
+                },
+
+                other => return other,
+            }
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let hint_sup = self.iter.size_hint().1;
+        (0, hint_sup)
+    }
+}
+
+#[test]
+fn test_try_filter_ok() {
+    use std::str::FromStr;
+
+    let v = ["1", "2", "a", "4", "5"]
+        .iter()
+        .map(Ok)
+        .try_filter_ok(|e| usize::from_str(e).map(|txt| txt < 3))
+        .collect::<Vec<Result<_, _>>>();
+
+    assert_eq!(v.len(), 3);
+    assert_eq!(v.iter().filter(|x| x.is_ok()).count(), 2);
+    assert_eq!(v.iter().filter(|x| x.is_err()).count(), 1);
+}

--- a/src/try_filter_map.rs
+++ b/src/try_filter_map.rs
@@ -1,0 +1,100 @@
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+/// Extension trait for `Iterator<Item = Result<O, E>>` to selectively transform and map Oks and Errors.
+pub trait TryFilterMap<O, E>: Sized {
+    /// Equivalent to [Iterator::filter_map] on all `Ok` values.
+    /// The filter function can fail with a result and turn an
+    /// [Result::Ok] into a [Result::Err]
+    ///
+    /// ```
+    /// use std::str::FromStr;
+    /// use resiter::try_filter_map::TryFilterMap;
+    ///
+    /// let filter_mapped: Vec<_> = vec![
+    ///     Ok("1"),
+    ///     Err("2".to_owned()),
+    ///     Ok("a"), // will become an error
+    ///     Err("4".to_owned()),
+    ///     Ok("5"), // will be filtered out
+    ///     Err("b".to_owned()),
+    ///     Err("8".to_owned()),
+    /// ]
+    /// .into_iter()
+    /// .try_filter_map(|txt| {
+    ///     match usize::from_str(txt).map_err(|e| e.to_string()) {
+    ///         Err(e) => Some(Err(e)),
+    ///         Ok(u) => {
+    ///             if u < 3 {
+    ///                 Some(Ok(u))
+    ///             } else {
+    ///                 None
+    ///             }
+    ///         }
+    ///     }
+    /// })
+    /// .collect();
+    ///
+    /// assert_eq!(
+    ///     filter_mapped,
+    ///     [
+    ///         Ok(1),
+    ///         Err("2".to_owned()),
+    ///         Err("invalid digit found in string".to_owned()),
+    ///         Err("4".to_owned()),
+    ///         Err("b".to_owned()),
+    ///         Err("8".to_owned())
+    ///     ]
+    /// );
+    /// ```
+    fn try_filter_map<F, O2>(self, _: F) -> TryFilterMapOk<Self, F>
+    where
+        F: FnMut(O) -> Option<Result<O2, E>>;
+}
+
+impl<I, O, E> TryFilterMap<O, E> for I
+where
+    I: Iterator<Item = Result<O, E>> + Sized,
+{
+    fn try_filter_map<F, O2>(self, f: F) -> TryFilterMapOk<Self, F>
+    where
+        F: FnMut(O) -> Option<Result<O2, E>>,
+    {
+        TryFilterMapOk { iter: self, f }
+    }
+}
+
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct TryFilterMapOk<I, F> {
+    iter: I,
+    f: F,
+}
+
+impl<I, O, E, F, O2> Iterator for TryFilterMapOk<I, F>
+where
+    I: Iterator<Item = Result<O, E>>,
+    F: FnMut(O) -> Option<Result<O2, E>>,
+{
+    type Item = Result<O2, E>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            return match self.iter.next() {
+                Some(Ok(x)) => match (self.f)(x) {
+                    Some(r) => Some(r),
+                    None => continue,
+                },
+                Some(Err(e)) => Some(Err(e)),
+                None => None,
+            };
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}


### PR DESCRIPTION
I renamed `FilterAndThen::filter_and_then` to `TryFilter::try_filter_map` and moved `try_filter` from `Filter` to `TryFilter`. 
I also converted the unit test to a doctest and moved the 'a' that yields a parse-error behind the '4' to demonstrate that the method both filters the values in ok and stops at the first error.