### PR TITLE
Document on err

### DIFF
--- a/src/onerr.rs
+++ b/src/onerr.rs
@@ -8,13 +8,13 @@
 pub struct OnErr<I, O, E, F>(I, F)
 where
     I: Iterator<Item = Result<O, E>>,
-    F: Fn(&E);
+    F: FnMut(&E);
 
 /// Extension trait for `Iterator<Item = Result<T, E>>` to do something on `Err(_)`
 pub trait OnErrDo<I, O, E, F>
 where
     I: Iterator<Item = Result<O, E>>,
-    F: Fn(&E),
+    F: FnMut(&E),
 {
     fn on_err(self, _: F) -> OnErr<I, O, E, F>;
 }
@@ -22,7 +22,7 @@ where
 impl<I, O, E, F> OnErrDo<I, O, E, F> for I
 where
     I: Iterator<Item = Result<O, E>>,
-    F: Fn(&E),
+    F: FnMut(&E),
 {
     fn on_err(self, f: F) -> OnErr<I, O, E, F> {
         OnErr(self, f)
@@ -32,7 +32,7 @@ where
 impl<I, O, E, F> Iterator for OnErr<I, O, E, F>
 where
     I: Iterator<Item = Result<O, E>>,
-    F: Fn(&E),
+    F: FnMut(&E),
 {
     type Item = Result<O, E>;
 

--- a/src/onerr.rs
+++ b/src/onerr.rs
@@ -16,6 +16,23 @@ where
     I: Iterator<Item = Result<O, E>>,
     F: FnMut(&E),
 {
+    /// Apply a sideffect on each `Err`
+    ///
+    /// ```
+    /// use resiter::onerr::OnErrDo;
+    /// use std::str::FromStr;
+    /// let mut errs = Vec::<::std::num::ParseIntError>::new();
+    ///
+    /// let _: Vec<Result<usize, ::std::num::ParseIntError>> = ["1", "2", "a", "b", "5"]
+    ///     .iter()
+    ///     .map(|e| usize::from_str(e))
+    ///     .on_err(|e| {
+    ///         errs.push(e.to_owned())
+    ///     })
+    ///     .collect();
+    ///
+    /// assert_eq!(errs.len(), 2);
+    /// ```
     fn on_err(self, _: F) -> OnErr<I, O, E, F>;
 }
 
@@ -44,15 +61,4 @@ where
             })
         })
     }
-}
-
-#[test]
-fn test_compile_1() {
-    use std::str::FromStr;
-
-    let _: Vec<Result<usize, ::std::num::ParseIntError>> = ["1", "2", "3", "4", "5"]
-        .iter()
-        .map(|e| usize::from_str(e))
-        .on_err(|e| println!("Error: {:?}", e))
-        .collect();
 }

--- a/src/onerr.rs
+++ b/src/onerr.rs
@@ -21,8 +21,8 @@ where
     /// ```
     /// use resiter::onerr::OnErrDo;
     /// use std::str::FromStr;
-    /// let mut errs = Vec::<::std::num::ParseIntError>::new();
     ///
+    /// let mut errs = Vec::<::std::num::ParseIntError>::new();
     /// let _: Vec<Result<usize, ::std::num::ParseIntError>> = ["1", "2", "a", "b", "5"]
     ///     .iter()
     ///     .map(|e| usize::from_str(e))


### PR DESCRIPTION
Two things has happened in this branch:
`OnErr` now uses an `FnMut` instead of an `Fn` which makes it posible to perform side effects on mutable external values in the context of the closure. This improves(?) on the existing functionality but should be backwards compatible if I grooked the rules for `FnOnce`, `Fn`, and `FnMut` correctly.

The other is the usual documentation with a test that actually demonstrates that OnErr is run on every Err.