### PR TITLE
Add inline macro annotations

### DIFF
--- a/src/and_then.rs
+++ b/src/and_then.rs
@@ -57,12 +57,15 @@ impl<I, O, E> AndThen<O, E> for I
 where
     I: Iterator<Item = Result<O, E>> + Sized,
 {
+    #[inline]
     fn and_then_ok<F, O2>(self, f: F) -> AndThenOk<Self, F>
     where
         F: FnMut(O) -> Result<O2, E>,
     {
         AndThenOk { iter: self, f }
     }
+
+    #[inline]
     fn and_then_err<F, E2>(self, f: F) -> AndThenErr<Self, F>
     where
         F: FnMut(E) -> Result<O, E2>,

--- a/src/and_then_filter.rs
+++ b/src/and_then_filter.rs
@@ -59,6 +59,7 @@ impl<I, O, E> AndThenFilter<O, E> for I
 where
     I: Iterator<Item = Result<O, E>> + Sized,
 {
+    #[inline]
     fn and_then_filter<F, O2>(self, f: F) -> AndThenFilterOk<Self, F>
     where
         F: FnMut(O) -> Option<Result<O2, E>>,

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -49,12 +49,15 @@ impl<I, O, E> Filter<O, E> for I
 where
     I: Iterator<Item = Result<O, E>> + Sized,
 {
+    #[inline]
     fn filter_ok<F>(self, f: F) -> FilterOk<Self, F>
     where
         F: FnMut(&O) -> bool,
     {
         FilterOk { iter: self, f }
     }
+
+    #[inline]
     fn filter_err<F>(self, f: F) -> FilterErr<Self, F>
     where
         F: FnMut(&E) -> bool,

--- a/src/filter_map.rs
+++ b/src/filter_map.rs
@@ -42,6 +42,7 @@ where
     /// assert_eq!(filter_mapped[4], Err("b"));
     /// assert_eq!(filter_mapped[5], Err("8"));
     /// ```
+    #[inline]
     fn filter_map_ok<F, O2>(self, f: F) -> FilterMapOk<Self, F>
     where
         F: FnMut(O) -> Option<O2>,
@@ -74,6 +75,7 @@ where
     /// assert_eq!(filter_mapped[4], Ok("5"));
     /// assert_eq!(filter_mapped[5], Err(8));
     /// ```
+    #[inline]
     fn filter_map_err<F, E2>(self, f: F) -> FilterMapErr<Self, F>
     where
         F: FnMut(E) -> Option<E2>,

--- a/src/flat_map.rs
+++ b/src/flat_map.rs
@@ -47,6 +47,7 @@ impl<I, O, E> FlatMap<O, E> for I
 where
     I: Iterator<Item = Result<O, E>> + Sized,
 {
+    #[inline]
     fn flat_map_ok<U, F, O2>(self, f: F) -> FlatMapOk<Self, U, F>
     where
         F: FnMut(O) -> U,
@@ -58,6 +59,8 @@ where
             f,
         }
     }
+
+    #[inline]
     fn flat_map_err<U, F, E2>(self, f: F) -> FlatMapErr<Self, U, F>
     where
         F: FnMut(E) -> U,

--- a/src/flatten.rs
+++ b/src/flatten.rs
@@ -62,6 +62,7 @@ impl<I, O, E> Flatten<O, E> for I
 where
     I: Iterator<Item = Result<O, E>> + Sized,
 {
+    #[inline]
     fn flatten_ok<U, O2>(self) -> FlattenOk<Self, U>
     where
         U: IntoIterator<Item = O2>,
@@ -71,6 +72,8 @@ where
             iter: self,
         }
     }
+
+    #[inline]
     fn flatten_err<U, E2>(self) -> FlattenErr<Self, U>
     where
         U: IntoIterator<Item = E2>,

--- a/src/map.rs
+++ b/src/map.rs
@@ -59,12 +59,15 @@ impl<I, O, E> Map<O, E> for I
 where
     I: Iterator<Item = Result<O, E>> + Sized,
 {
+    #[inline]
     fn map_ok<F, O2>(self, f: F) -> MapOk<Self, F>
     where
         F: FnMut(O) -> O2,
     {
         MapOk { iter: self, f }
     }
+
+    #[inline]
     fn map_err<F, E2>(self, f: F) -> MapErr<Self, F>
     where
         F: FnMut(E) -> E2,

--- a/src/ok_or_else.rs
+++ b/src/ok_or_else.rs
@@ -40,6 +40,7 @@ where
     E: Sized,
     F: FnOnce() -> E,
 {
+    #[inline]
     fn inner_ok_or_else(self, f: F) -> Result<T, E> {
         self.and_then(|opt| opt.ok_or_else(f))
     }
@@ -94,6 +95,7 @@ where
     E: Sized,
     F: Fn() -> E,
 {
+    #[inline]
     fn map_inner_ok_or_else(self, f: F) -> IterInnerOkOrElseImpl<I, T, E, F> {
         IterInnerOkOrElseImpl(self, f)
     }

--- a/src/oks.rs
+++ b/src/oks.rs
@@ -41,6 +41,7 @@ impl<T, E, I> GetOks<T, E> for I
 where
     I: Iterator<Item = Result<T, E>> + Sized,
 {
+    #[inline]
     #[allow(clippy::type_complexity)]
     fn oks(self) -> FilterMap<Self, fn(Result<T, E>) -> Option<T>> {
         self.filter_map(GetOk::get_ok)

--- a/src/onerr.rs
+++ b/src/onerr.rs
@@ -41,6 +41,7 @@ where
     I: Iterator<Item = Result<O, E>>,
     F: FnMut(&E),
 {
+    #[inline]
     fn on_err(self, f: F) -> OnErr<I, O, E, F> {
         OnErr(self, f)
     }

--- a/src/onok.rs
+++ b/src/onok.rs
@@ -39,6 +39,7 @@ where
     I: Iterator<Item = Result<O, E>>,
     F: FnMut(&O),
 {
+    #[inline]
     fn on_ok(self, f: F) -> OnOk<I, O, E, F> {
         OnOk(self, f)
     }

--- a/src/try_filter.rs
+++ b/src/try_filter.rs
@@ -33,6 +33,7 @@ impl<I, O, E> TryFilter<O, E> for I
 where
     I: Iterator<Item = Result<O, E>> + Sized,
 {
+    #[inline]
     fn try_filter_ok<F>(self, f: F) -> TryFilterOk<Self, F>
     where
         F: FnMut(&O) -> Result<bool, E>,

--- a/src/try_filter_map.rs
+++ b/src/try_filter_map.rs
@@ -106,6 +106,7 @@ impl<I, O, E> TryFilterMap<O, E> for I
 where
     I: Iterator<Item = Result<O, E>> + Sized,
 {
+    #[inline]
     fn try_filter_map_ok<F, O2>(self, f: F) -> TryFilterMapOk<Self, F>
     where
         F: FnMut(O) -> Option<Result<O2, E>>,

--- a/src/unwrap.rs
+++ b/src/unwrap.rs
@@ -82,6 +82,7 @@ where
     I: Iterator<Item = Result<O, E>>,
     F: FnMut(E) -> Option<O>,
 {
+    #[inline]
     fn unwrap_with(self, f: F) -> UnwrapWith<I, O, E, F> {
         UnwrapWith(self, f)
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -33,6 +33,7 @@ pub trait Process<T> {
 
 impl<I: Iterator> Process<I::Item> for I {
     /// Process all errors with a lambda
+    #[inline]
     fn process<R: Default, E, F>(self, f: F) -> Result<R, E>
     where
         F: Fn(I::Item) -> Result<R, E>,

--- a/src/while_ok.rs
+++ b/src/while_ok.rs
@@ -46,6 +46,7 @@ impl<I, O, E> WhileOk<O, E> for I
 where
     I: Iterator<Item = Result<O, E>>,
 {
+    #[inline]
     fn while_ok<F>(self, mut f: F) -> Result<(), E>
     where
         F: FnMut(O),


### PR DESCRIPTION
This patch adds #[inline] to all functions that are trivial or helper functions for constructing iterator adaptors.

---

Not sure how much it helps, but if it helps a little, that's already something :laughing: 