### PR TITLE
Put tests in cfg(test)

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -133,28 +133,33 @@ where
     }
 }
 
-#[test]
-fn test_filter_ok_hint() {
-    use std::str::FromStr;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    let hint = ["1", "2", "a", "4", "5"]
-        .iter()
-        .map(|txt| usize::from_str(txt))
-        .filter_ok(|i| i % 2 == 0)
-        .size_hint();
+    #[test]
+    fn test_filter_ok_hint() {
+        use std::str::FromStr;
 
-    assert_eq!(hint, (0, Some(5)));
-}
+        let hint = ["1", "2", "a", "4", "5"]
+            .iter()
+            .map(|txt| usize::from_str(txt))
+            .filter_ok(|i| i % 2 == 0)
+            .size_hint();
 
-#[test]
-fn test_filter_err_hint() {
-    use std::str::FromStr;
+        assert_eq!(hint, (0, Some(5)));
+    }
 
-    let hint = ["1", "2", "a", "4", "5"]
-        .iter()
-        .map(|txt| usize::from_str(txt))
-        .filter_err(|_| false)
-        .size_hint();
+    #[test]
+    fn test_filter_err_hint() {
+        use std::str::FromStr;
 
-    assert_eq!(hint, (0, Some(5)));
+        let hint = ["1", "2", "a", "4", "5"]
+            .iter()
+            .map(|txt| usize::from_str(txt))
+            .filter_err(|_| false)
+            .size_hint();
+
+        assert_eq!(hint, (0, Some(5)));
+    }
 }

--- a/src/filter_map.rs
+++ b/src/filter_map.rs
@@ -147,28 +147,33 @@ where
     }
 }
 
-#[test]
-fn test_filter_map_ok_hint() {
-    use std::str::FromStr;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    let hint = ["1", "2", "a", "4", "5"]
-        .iter()
-        .map(|txt| usize::from_str(txt))
-        .filter_map_ok(|i| Some(2 * i))
-        .size_hint();
+    #[test]
+    fn test_filter_map_ok_hint() {
+        use std::str::FromStr;
 
-    assert_eq!(hint, (5, Some(5)));
-}
+        let hint = ["1", "2", "a", "4", "5"]
+            .iter()
+            .map(|txt| usize::from_str(txt))
+            .filter_map_ok(|i| Some(2 * i))
+            .size_hint();
 
-#[test]
-fn test_filter_map_err_hint() {
-    use std::str::FromStr;
+        assert_eq!(hint, (5, Some(5)));
+    }
 
-    let hint = ["1", "2", "a", "4", "5"]
-        .iter()
-        .map(|txt| usize::from_str(txt))
-        .filter_map_err(|e| Some(format!("{:?}", e)))
-        .size_hint();
+    #[test]
+    fn test_filter_map_err_hint() {
+        use std::str::FromStr;
 
-    assert_eq!(hint, (5, Some(5)));
+        let hint = ["1", "2", "a", "4", "5"]
+            .iter()
+            .map(|txt| usize::from_str(txt))
+            .filter_map_err(|e| Some(format!("{:?}", e)))
+            .size_hint();
+
+        assert_eq!(hint, (5, Some(5)));
+    }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -119,28 +119,33 @@ where
     }
 }
 
-#[test]
-fn test_map_ok_hint() {
-    use std::str::FromStr;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    let hint = ["1", "2", "a", "4", "5"]
-        .iter()
-        .map(|txt| usize::from_str(txt))
-        .map_ok(|i| 2 * i)
-        .size_hint();
+    #[test]
+    fn test_map_ok_hint() {
+        use std::str::FromStr;
 
-    assert_eq!(hint, (5, Some(5)));
-}
+        let hint = ["1", "2", "a", "4", "5"]
+            .iter()
+            .map(|txt| usize::from_str(txt))
+            .map_ok(|i| 2 * i)
+            .size_hint();
 
-#[test]
-fn test_map_err_hint() {
-    use std::str::FromStr;
+        assert_eq!(hint, (5, Some(5)));
+    }
 
-    let hint = ["1", "2", "a", "4", "5"]
-        .iter()
-        .map(|txt| usize::from_str(txt))
-        .map_err(|e| format!("{:?}", e))
-        .size_hint();
+    #[test]
+    fn test_map_err_hint() {
+        use std::str::FromStr;
 
-    assert_eq!(hint, (5, Some(5)));
+        let hint = ["1", "2", "a", "4", "5"]
+            .iter()
+            .map(|txt| usize::from_str(txt))
+            .map_err(|e| format!("{:?}", e))
+            .size_hint();
+
+        assert_eq!(hint, (5, Some(5)));
+    }
 }


### PR DESCRIPTION
Not sure how well these are removed from the binary when compiled, so we add a little 'cfg(test)' here to ensure that these are gone when not required.