### PR TITLE
Add `FoldUnit` trait helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,31 @@ iter.inner_ok_or_else(|| error())                      // resiter
 * Executing code for each error in `Iterator<Item = Result<T, E>>`
 
 ```rust
-iter.map(|r| if let Err(e) = r { foo(); Err(e) } else { r })) // stdlib
+iter.map(|r| if let Err(e) = r { foo(); Err(e) } else { r })  // stdlib
 iter.map(|r| r.map_err(|e| { foo(); e }))                     // stdlib
 iter.on_err(|e| foo())                                        // resiter
+```
+
+
+* Fail fast the `Iterator<Item = Result<(), E>>`
+
+```rust
+for r in iter { r?; }                                         // stdlib
+iter.fail_fast()?;                                            // resiter
+```
+
+
+* Process every item of `Iterator<Item = Result<Unit, E>>`, returning the last error only
+
+```rust
+fn erroneous<T, E>(x: T) -> Result<(), E> {
+    ...
+}
+
+let err = iter.map(erroneous).filter_map(Result::err).last(); // stdlib
+if let Some(last_err) = err { return Err(last_err); }         //
+
+iter.map(erroneous).last_err()?;                              // resiter
 ```
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,29 @@
 //! }
 //! ```
 //!
+//!
+//! * Processing the erroneous (side-effect) iteration, producing only the last error if any
+//!
+//! ```
+//! use std::str::FromStr;
+//! use resiter::unit::*;
+//!
+//! let mut acc = vec![];
+//! let mut do_side_effect = |i: Result<usize, _>| {
+//!     i.map(|i| {
+//!         println!("{} is a usize", i);
+//!         acc.push(i);
+//!     })
+//! };
+//!
+//! let res = ["1", "2", "foo", "4", "5"]
+//!     .into_iter()
+//!     .map(|e| do_side_effect(usize::from_str(e)))
+//!     .last_err();
+//! assert_eq!(acc, vec![1, 2, 4, 5]);
+//! assert!(res.is_err());
+//! ```
+//!
 //! # License
 //!
 //! MPL 2.0
@@ -193,6 +216,7 @@ pub mod prelude;
 pub mod try_filter;
 pub mod try_filter_map;
 pub mod try_map;
+pub mod unit;
 pub mod unwrap;
 mod util;
 pub mod while_ok;
@@ -211,6 +235,7 @@ pub use onok::OnOkDo;
 pub use try_filter::TryFilter;
 pub use try_filter_map::TryFilterMap;
 pub use try_map::TryMap;
+pub use unit::FoldUnit;
 pub use unwrap::UnwrapWithExt;
 pub use util::{GetErr, GetOk, Process};
 pub use while_ok::WhileOk;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -23,5 +23,6 @@ pub use onok::*;
 pub use try_filter::*;
 pub use try_filter_map::*;
 pub use try_map::*;
+pub use unit::*;
 pub use unwrap::*;
 pub use while_ok::*;

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -1,0 +1,114 @@
+use crate::errors::GetErrors as _;
+
+/// Extension trait for `Iterator<Item = Result<(), E>>` (or other `T` _isomorphic_ to unit `()`)
+/// to fold into a single value.
+pub trait FoldUnit<T, E>: Iterator<Item = Result<T, E>> {
+    /// Stop on the first [`Err`] output by skipping all the consequent items.
+    ///
+    /// # Examples
+    ///
+    /// Implemented for `Result<(), E>` the following two implementations are roughly equivalent:
+    ///
+    /// ```
+    /// # use resiter::FoldUnit;
+    ///
+    /// type UnitResult<E> = Result<(), E>;
+    ///
+    /// fn process_side_effects<E>(mut iter: impl Iterator<Item=UnitResult<E>>) -> UnitResult<E> {
+    ///   for x in iter {
+    ///     x?;
+    ///   }
+    ///   Ok(())
+    /// }
+    ///
+    /// fn process_side_effects_with_fail_fast<E>(mut iter: impl Iterator<Item=UnitResult<E>>) -> UnitResult<E> {
+    ///   iter.fail_fast()
+    /// }
+    ///
+    /// let values = vec![Ok(()), Ok(()), Err("error1"), Ok(()), Err("error2")];
+    /// assert_eq!(process_side_effects(values.clone().into_iter()), Err("error1"));
+    /// assert_eq!(process_side_effects_with_fail_fast(values.into_iter()), Err("error1"));
+    /// ```
+    ///
+    /// Also works for `Result<T, E>` where `T` is the other unit type (may be constructed `From<()>`):
+    /// ```
+    /// # use resiter::FoldUnit;
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Unit;
+    /// impl From<()> for Unit {
+    ///     fn from(_: ()) -> Self {
+    ///         Unit
+    ///     }
+    /// }
+    ///
+    /// let values = vec![Ok(Unit), Ok(Unit), Err("error1"), Ok(Unit), Err("error2")];
+    /// assert_eq!(values.into_iter().fail_fast(), Err("error1"));
+    /// ```
+    ///
+    /// See also for somewhat similar functionality: [`Errors`][crate::errors::Errors];
+    fn fail_fast(&mut self) -> Result<T, E>;
+
+    /// Process the iterator till the end, ignoring all but the last [`Err`].
+    ///
+    /// This is mostly useful for the stateful calculations
+    /// to ensure independent processing of *every** individual [`Self::Item`]
+    /// is done even if some of them are erroneous.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::str::FromStr;
+    /// # use resiter::FoldUnit;
+    /// let mut acc = vec![];
+    /// let mut do_side_effect = |i: Result<usize, _>| {
+    ///     i.map(|i| {
+    ///         println!("{} is a usize", i);
+    ///         acc.push(i);
+    ///     })
+    /// };
+    ///
+    /// let values = vec!["1", "2", "foo", "4", "5"];
+    /// let res = values
+    ///     .iter().copied()
+    ///     .map(|e| do_side_effect(usize::from_str(e).map_err(|_| e)))
+    ///     .last_err();
+    /// assert_eq!(acc.as_slice(), &[1, 2, 4, 5]);
+    /// assert_eq!(res, Err("foo"));
+    /// ```
+    ///
+    /// Also works for `Result<T, E>` where `T` is the other unit type (may be constructed `From<()>`):
+    /// ```
+    /// # use resiter::FoldUnit;
+    ///
+    /// #[derive(Debug, PartialEq)]
+    /// struct Unit;
+    /// impl From<()> for Unit {
+    ///     fn from(_: ()) -> Self {
+    ///         Unit
+    ///     }
+    /// }
+    ///
+    /// let values = vec![Ok(Unit), Ok(Unit), Err("error1"), Ok(Unit), Err("error2")];
+    /// assert_eq!(values.into_iter().last_err(), Err("error2"));
+    /// ```
+    ///
+    /// See also for somewhat similar functionality:
+    /// - [`WhileOk`][crate::while_ok::WhileOk];
+    /// - [`OnOkDo`][crate::onok::OnOkDo];
+    fn last_err(&mut self) -> Result<T, E>;
+}
+
+impl<I, T, E> FoldUnit<T, E> for I
+where
+    I: Iterator<Item = Result<T, E>>,
+    T: From<()>,
+{
+    fn fail_fast(&mut self) -> Result<T, E> {
+        self.errors().next().map_or_else(|| Ok(().into()), Err)
+    }
+
+    fn last_err(&mut self) -> Result<T, E> {
+        self.errors().last().map_or_else(|| Ok(().into()), Err)
+    }
+}


### PR DESCRIPTION
Simplify the `?` workflow by only considering a single `Err` variant (first or last one):


* Fail fast the `Iterator<Item = Result<(), E>>`

```rust
for r in iter { r?; }                                         // stdlib
iter.fail_fast()?;                                            // resiter
```


* Process every item of `Iterator<Item = Result<Unit, E>>`, returning the last error only

```rust
fn erroneous<E>(x) -> Result<(), E> {
    ...
}

let err = iter.map(erroneous).filter_map(Result::err).last(); // stdlib
if let Some(last_err) = err { return Err(last_err); }         //

iter.map(erroneous).last_err()?;                              // resiter
```
